### PR TITLE
Move RFC7997 to the informative section

### DIFF
--- a/draft-rswg-rfc7997bis.mkd
+++ b/draft-rswg-rfc7997bis.mkd
@@ -37,6 +37,7 @@ normative:
 informative:
   RFC20:
   RFC6365:
+  RFC7997:
 
 --- abstract
 


### PR DESCRIPTION
I *believe* that the RFC being obsoleted should be a informative reference.